### PR TITLE
Dispatch text changes immediately

### DIFF
--- a/vue2-vuetify/src/controls/DateControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateControlRenderer.vue
@@ -18,7 +18,7 @@
       :required="control.required"
       :error-messages="control.errors"
       :value="control.data"
-      @change="onChange"
+      @input="onChange"
       @focus="isFocused = true"
       @blur="isFocused = false"
     />

--- a/vue2-vuetify/src/controls/IntegerControlRenderer.vue
+++ b/vue2-vuetify/src/controls/IntegerControlRenderer.vue
@@ -19,7 +19,7 @@
       :required="control.required"
       :error-messages="control.errors"
       :value="control.data"
-      @change="onChange"
+      @input="onChange"
       @focus="isFocused = true"
       @blur="isFocused = false"
     />

--- a/vue2-vuetify/src/controls/MultiStringControlRenderer.vue
+++ b/vue2-vuetify/src/controls/MultiStringControlRenderer.vue
@@ -29,7 +29,7 @@
         "
         :clearable="hover"
         multi-line
-        @change="onChange"
+        @input="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />

--- a/vue2-vuetify/src/controls/NumberControlRenderer.vue
+++ b/vue2-vuetify/src/controls/NumberControlRenderer.vue
@@ -19,7 +19,7 @@
       :required="control.required"
       :error-messages="control.errors"
       :value="control.data"
-      @change="onChange"
+      @input="onChange"
       @focus="isFocused = true"
       @blur="isFocused = false"
     />

--- a/vue2-vuetify/src/controls/PasswordControlRenderer.vue
+++ b/vue2-vuetify/src/controls/PasswordControlRenderer.vue
@@ -28,7 +28,7 @@
           ? control.schema.maxLength
           : undefined
       "
-      @change="onChange"
+      @input="onChange"
       @focus="isFocused = true"
       @blur="isFocused = false"
     />

--- a/vue2-vuetify/src/controls/StringControlRenderer.vue
+++ b/vue2-vuetify/src/controls/StringControlRenderer.vue
@@ -31,7 +31,7 @@
         :value="control.data"
         :items="suggestions"
         hide-no-data
-        @change="onChange"
+        @input="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />
@@ -58,7 +58,7 @@
             : undefined
         "
         :clearable="hover"
-        @change="onChange"
+        @input="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />

--- a/vue2-vuetify/src/controls/TimeControlRenderer.vue
+++ b/vue2-vuetify/src/controls/TimeControlRenderer.vue
@@ -18,7 +18,7 @@
       :required="control.required"
       :error-messages="control.errors"
       :value="control.data"
-      @change="onChange"
+      @input="onChange"
       @focus="isFocused = true"
       @blur="isFocused = false"
     />

--- a/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -46,7 +46,7 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        @change="onChange"
+        @input="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />

--- a/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -46,7 +46,7 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        @change="onChange"
+        @input="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />


### PR DESCRIPTION
Hook the update mechanism to `@input` instead of `@change` for text
based inputs. This allows JSON Forms to validate new data immediatly
insetad of waiting for the user to 'exit' the current input. However
this has a negative effect on performance.