### PR TITLE
Expand new array layout items by default

### DIFF
--- a/example/src/components/Settings.vue
+++ b/example/src/components/Settings.vue
@@ -192,8 +192,22 @@
             <v-tooltip bottom>
               <template v-slot:activator="{ on: onTooltip }">
                 <v-switch
+                  v-model="collapseNewItems"
+                  label="Collapse new items"
+                  v-on="onTooltip"
+                ></v-switch>
+              </template>
+              If true, new array items are not expanded by default
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on: onTooltip }">
+                <v-switch
                   v-model="locale"
-                  label="Switch beetwen english and german locale"
+                  label="Switch between english and german locale"
                   v-on="onTooltip"
                 ></v-switch>
               </template>
@@ -220,6 +234,7 @@ export default {
       'app/jsonforms@config.showUnfocusedDescription'
     ),
     restrict: sync('app/jsonforms@config.restrict'),
+    collapseNewItems: sync('app/jsonforms@config.collapseNewItems'),
     readonly: sync('app/jsonforms@readonly'),
     locale: sync('app/jsonforms@locale'),
   },

--- a/example/src/store/modules/app.ts
+++ b/example/src/store/modules/app.ts
@@ -18,6 +18,7 @@ const state: AppState = {
       trim: false,
       showUnfocusedDescription: false,
       hideRequiredAsterisk: true,
+      collapseNewItems: false,
     },
     renderers: extendedVuetifyRenderers,
     cells: extendedVuetifyRenderers,

--- a/example/src/store/modules/types.ts
+++ b/example/src/store/modules/types.ts
@@ -16,6 +16,7 @@ export interface AppState {
       trim: boolean;
       showUnfocusedDescription: boolean;
       hideRequiredAsterisk: boolean;
+      collapseNewItems: boolean;
     };
     renderers: JsonFormsRendererRegistryEntry[];
     cells: JsonFormsCellRendererRegistryEntry[];

--- a/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -40,7 +40,7 @@
     <v-card-text>
       <v-container justify-space-around align-content-center>
         <v-row justify="center">
-          <v-expansion-panels accordion focusable>
+          <v-expansion-panels accordion focusable v-model="currentlyExpanded">
             <v-expansion-panel
               v-for="(element, index) in control.data"
               :key="`${control.path}-${index}`"
@@ -218,6 +218,7 @@ import {
 } from 'vuetify/lib';
 import { ValidationIcon, ValidationBadge } from '../controls/components/index';
 import { ErrorObject } from 'ajv';
+import { ref } from '@vue/composition-api';
 
 const controlRenderer = defineComponent({
   name: 'array-layout-renderer',
@@ -247,7 +248,9 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyArrayControl(useJsonFormsArrayControl(props));
+    const control = useVuetifyArrayControl(useJsonFormsArrayControl(props));
+    const currentlyExpanded = ref<null | number>(null);
+    return { ...control, currentlyExpanded };
   },
   computed: {
     noData(): boolean {
@@ -280,6 +283,9 @@ const controlRenderer = defineComponent({
         this.control.path,
         createDefaultValue(this.control.schema)
       )();
+      if (!this.appliedOptions.collapseNewItems && this.control.data?.length) {
+        this.currentlyExpanded = this.control.data.length - 1;
+      }
     },
     moveUpClick(event: Event, toMove: number): void {
       event.stopPropagation();


### PR DESCRIPTION
Array layouts now expand new items by default. This behavior can
be disabled via the UI Schema option 'collapseNewItems'.

This can be directly tested within the example app.