### PR TITLE
Attach popups to application root

### DIFF
--- a/vue2-vuetify/src/controls/EnumControlRenderer.vue
+++ b/vue2-vuetify/src/controls/EnumControlRenderer.vue
@@ -23,7 +23,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
         @focus="isFocused = true"

--- a/vue2-vuetify/src/controls/OneOfEnumControlRenderer.vue
+++ b/vue2-vuetify/src/controls/OneOfEnumControlRenderer.vue
@@ -23,7 +23,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
         @focus="isFocused = true"

--- a/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -24,7 +24,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
         @focus="isFocused = true"
@@ -48,7 +47,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-autocomplete')"
         @input="onChange"
         @focus="isFocused = true"

--- a/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -24,7 +24,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
         @focus="isFocused = true"
@@ -48,7 +47,6 @@
         :items="control.options"
         item-text="label"
         item-value="value"
-        attach
         v-bind="vuetifyProps('v-autocomplete')"
         @input="onChange"
         @focus="isFocused = true"


### PR DESCRIPTION
When attaching v-select or v-autocomplete to their parent elements then they
are potentially cut off by their surrounding container, e.g. the table control
or group layout.

The attach prop is now removed for them, letting them attach to the application
root, avoiding the cutoff problems.

Fixes #38 