### PR TITLE
Properly clear date/time values

### DIFF
--- a/vue2-vuetify/src/controls/DateControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateControlRenderer.vue
@@ -53,7 +53,11 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyControl(useJsonFormsControl(props), undefined, 300);
+    return useVuetifyControl(
+      useJsonFormsControl(props),
+      (value) => value || undefined,
+      300
+    );
   },
 });
 

--- a/vue2-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -52,7 +52,11 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyControl(useJsonFormsControl(props));
+    return useVuetifyControl(
+      useJsonFormsControl(props),
+      (value) => value || undefined,
+      300
+    );
   },
   computed: {
     dataTime: {

--- a/vue2-vuetify/src/controls/TimeControlRenderer.vue
+++ b/vue2-vuetify/src/controls/TimeControlRenderer.vue
@@ -53,7 +53,11 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyControl(useJsonFormsControl(props), undefined, 300);
+    return useVuetifyControl(
+      useJsonFormsControl(props),
+      (value) => value || undefined,
+      300
+    );
   },
 });
 


### PR DESCRIPTION
When the date, time and date-time inputs are cleared, their value will now be set to
undefined. Previously they were saved as empty strings, leading to AJV format errors.