### PR TITLE
Expand first array item initially

### DIFF
--- a/example/src/components/Settings.vue
+++ b/example/src/components/Settings.vue
@@ -194,11 +194,25 @@
               <template v-slot:activator="{ on: onTooltip }">
                 <v-switch
                   v-model="collapseNewItems"
-                  label="Collapse new items"
+                  label="Collapse new array items"
                   v-on="onTooltip"
                 ></v-switch>
               </template>
               If true, new array items are not expanded by default
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on: onTooltip }">
+                <v-switch
+                  v-model="initCollapsed"
+                  label="Collapse arrays initially"
+                  v-on="onTooltip"
+                ></v-switch>
+              </template>
+              If true, arrays are not expanded initially
             </v-tooltip>
           </v-col>
         </v-row>
@@ -236,6 +250,7 @@ export default {
     ),
     restrict: sync('app/jsonforms@config.restrict'),
     collapseNewItems: sync('app/jsonforms@config.collapseNewItems'),
+    initCollapsed: sync('app/jsonforms@config.initCollapsed'),
     readonly: sync('app/jsonforms@readonly'),
     locale: sync('app/jsonforms@locale'),
     hideAvatar: sync('app/jsonforms@config.hideAvatar'),

--- a/example/src/store/modules/app.ts
+++ b/example/src/store/modules/app.ts
@@ -19,6 +19,7 @@ const state: AppState = {
       showUnfocusedDescription: false,
       hideRequiredAsterisk: true,
       collapseNewItems: false,
+      initCollapsed: false,
       hideAvatar: false,
     },
     renderers: extendedVuetifyRenderers,

--- a/example/src/store/modules/types.ts
+++ b/example/src/store/modules/types.ts
@@ -17,6 +17,7 @@ export interface AppState {
       showUnfocusedDescription: boolean;
       hideRequiredAsterisk: boolean;
       collapseNewItems: boolean;
+      initCollapsed: boolean;
       hideAvatar: boolean;
     };
     renderers: JsonFormsRendererRegistryEntry[];

--- a/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -286,7 +286,9 @@ const controlRenderer = defineComponent({
   },
   setup(props: RendererProps<ControlElement>) {
     const control = useVuetifyArrayControl(useJsonFormsArrayControl(props));
-    const currentlyExpanded = ref<null | number>(null);
+    const currentlyExpanded = ref<null | number>(
+      control.appliedOptions.value.initCollapsed ? null : 0
+    );
     const suggestToDelete = ref<null | number>(null);
     // indicate to our child renderers that we are increasing the "nested" level
     useNested('array');


### PR DESCRIPTION
By default the first array item will render expanded. This can be turned off via the new
'initCollapsed' UI Schema option.