### PR TITLE
Offer breakpoint option for horizontal layouts

### DIFF
--- a/example/src/components/Settings.vue
+++ b/example/src/components/Settings.vue
@@ -216,6 +216,20 @@
             </v-tooltip>
           </v-col>
         </v-row>
+        <v-container>
+          <v-row>
+            <v-row><v-col>Break horizontal layouts</v-col></v-row>
+            <v-col>
+              <v-select
+                outlined
+                persistent-hint
+                dense
+                v-model="breakHorizontal"
+                :items="breakHorizontals"
+              ></v-select>
+            </v-col>
+          </v-row>
+        </v-container>
         <v-row>
           <v-col>
             <v-tooltip bottom>
@@ -251,6 +265,7 @@ export default {
     restrict: sync('app/jsonforms@config.restrict'),
     collapseNewItems: sync('app/jsonforms@config.collapseNewItems'),
     initCollapsed: sync('app/jsonforms@config.initCollapsed'),
+    breakHorizontal: sync('app/jsonforms@config.breakHorizontal'),
     readonly: sync('app/jsonforms@readonly'),
     locale: sync('app/jsonforms@locale'),
     hideAvatar: sync('app/jsonforms@config.hideAvatar'),
@@ -266,6 +281,14 @@ export default {
       locales: [
         { text: 'English (en)', value: 'en' },
         { text: 'German (de)', value: 'de' },
+      ],
+      breakHorizontals: [
+        { text: 'None', value: false },
+        { text: 'xs', value: 'xs' },
+        { text: 'sm', value: 'sm' },
+        { text: 'md', value: 'md' },
+        { text: 'lg', value: 'lg' },
+        { text: 'xl', value: 'xl' },
       ],
     };
   },

--- a/example/src/store/modules/app.ts
+++ b/example/src/store/modules/app.ts
@@ -19,6 +19,7 @@ const state: AppState = {
       showUnfocusedDescription: false,
       hideRequiredAsterisk: true,
       collapseNewItems: false,
+      breakHorizontal: false,
       initCollapsed: false,
       hideAvatar: false,
     },

--- a/example/src/store/modules/types.ts
+++ b/example/src/store/modules/types.ts
@@ -18,6 +18,7 @@ export interface AppState {
       hideRequiredAsterisk: boolean;
       collapseNewItems: boolean;
       initCollapsed: boolean;
+      breakHorizontal: false | string;
       hideAvatar: boolean;
     };
     renderers: JsonFormsRendererRegistryEntry[];

--- a/vue2-vuetify/shims-vuetify.d.ts
+++ b/vue2-vuetify/shims-vuetify.d.ts
@@ -1,0 +1,4 @@
+declare module 'vuetify/lib/framework' {
+  import Vuetify from 'vuetify';
+  export default Vuetify;
+}

--- a/vue2-vuetify/src/layouts/HorizontalLayoutRenderer.vue
+++ b/vue2-vuetify/src/layouts/HorizontalLayoutRenderer.vue
@@ -9,6 +9,7 @@
         v-for="(element, index) in layout.uischema.elements"
         :key="`${layout.path}-${index}`"
         :class="styles.horizontalLayout.item"
+        :cols="cols"
         v-bind="vuetifyProps(`v-col[${index}]`)"
       >
         <dispatch-renderer
@@ -54,6 +55,33 @@ const layoutRenderer = defineComponent({
   },
   setup(props: RendererProps<Layout>) {
     return useVuetifyLayout(useJsonFormsLayout(props));
+  },
+  computed: {
+    cols() {
+      const { xs, sm, md, lg, xl } = this.$vuetify.breakpoint;
+      if (this.appliedOptions.breakHorizontal === 'xs' && xs) {
+        return 12;
+      }
+      if (this.appliedOptions.breakHorizontal === 'sm' && (xs || sm)) {
+        return 12;
+      }
+      if (this.appliedOptions.breakHorizontal === 'md' && (xs || sm || md)) {
+        return 12;
+      }
+      if (
+        this.appliedOptions.breakHorizontal === 'lg' &&
+        (xs || sm || md || lg)
+      ) {
+        return 12;
+      }
+      if (
+        this.appliedOptions.breakHorizontal === 'xl' &&
+        (xs || sm || md || lg || xl)
+      ) {
+        return 12;
+      }
+      return false;
+    },
   },
 });
 

--- a/vue2-vuetify/src/util/composition.ts
+++ b/vue2-vuetify/src/util/composition.ts
@@ -126,13 +126,23 @@ export const useTranslator = () => {
  * Adds styles and appliedOptions
  */
 export const useVuetifyLayout = <I extends { layout: any }>(input: I) => {
-  const appliedOptions = computed(() =>
-    merge(
+  // TODO: We consume 'config' here manually as it's not provided by the input.layout.
+  // Once it's provided there, we don't need to inject jsonforms again
+  const jsonforms = inject<JsonFormsSubStates>('jsonforms');
+
+  if (!jsonforms) {
+    throw new Error(
+      "'jsonforms couldn't be injected. Are you within JSON Forms?"
+    );
+  }
+
+  const appliedOptions = computed(() => {
+    return merge(
       {},
-      cloneDeep(input.layout.value.config),
+      cloneDeep(jsonforms.config),
       cloneDeep(input.layout.value.uischema.options)
-    )
-  );
+    );
+  });
 
   const vuetifyProps = (path: string) => {
     const props = get(appliedOptions.value?.vuetify, path);


### PR DESCRIPTION
The horizontal layout renderer now looks for the new 'breakHorizontal' UI Schema option.
This option can either be 'xs', 'sm', 'md', 'lg' or 'xl' which corresponds to the
breakpoint support of Vuetify. If no breaking behavior is wanted the option can be
anything else, e.g. 'false'.

The layout will render vertically if the given breakpoint, or a smaller one, is hit.
Thefore the layout will always render vertically when `xl` is given, while option 'xs'
will only break the layout on the smallest view ports.