### PR TITLE
Fix config merging in layout renderers

### DIFF
--- a/vue2-vuetify/src/util/composition.ts
+++ b/vue2-vuetify/src/util/composition.ts
@@ -129,7 +129,7 @@ export const useVuetifyLayout = <I extends { layout: any }>(input: I) => {
   const appliedOptions = computed(() => {
     return merge(
       {},
-      cloneDeep(input.layout.config),
+      cloneDeep(input.layout.value.config),
       cloneDeep(input.layout.value.uischema.options)
     );
   });


### PR DESCRIPTION
The global config is now taken into consideration for the 'appliedOptions' in layout
renderers.