### PR TITLE
Apply inherited background color to expansion panel headers

### DIFF
--- a/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -366,4 +366,7 @@ export const entry: JsonFormsRendererRegistryEntry = {
 .notranslate {
   transform: none !important;
 }
+.v-expansion-panel-header:before {
+  background-color: inherit;
+}
 </style>


### PR DESCRIPTION
The `v-expansion-panel` that is rendered for the `ArrayLayoutRenderer` is colored grey. The headers in the Vuetify docs are all white (or the parent background color). 

I tracked this down to `background-color: currentColor` being applied in in [VExpansionPanel.sass:153](https://github.com/vuetifyjs/vuetify/blob/8bb752b210d25fbebcea12cd073d2ce4986f5e12/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass#L153)

I'm not sure why this is causing the grey colour (from the user agent's default button style) to be applied in the `ArrayLayoutRenderer`, whereas in the Vuetify docs, the parent's background shows through.

This applies `background-color: inherit' on top of `background-color: currentColor`.