### PR TITLE
use v-model for pickers and return-value:sync

### DIFF
--- a/vue2-vuetify/src/controls/DateControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateControlRenderer.vue
@@ -30,8 +30,10 @@
         </template>
         <template slot="prepend-inner">
           <v-menu
+            ref="menu"
             v-model="showMenu"
             :close-on-content-click="false"
+            :return-value.sync="pickerValue"
             transition="scale-transition"
             offset-y
             min-width="290px"
@@ -41,7 +43,7 @@
             </template>
             <v-date-picker
               v-if="showMenu"
-              :value="pickerValue"
+              v-model="pickerValue"
               ref="picker"
               v-bind="vuetifyProps('v-date-picker')"
               :min="minDate"
@@ -220,12 +222,17 @@ const controlRenderer = defineComponent({
       const date = parseDateTime(value, this.formats);
       return date ? date.format(this.dateFormat) : value;
     },
-    pickerValue(): string | undefined {
-      const value = this.control.data;
+    pickerValue: {
+      get(): string | undefined {
+        const value = this.control.data;
 
-      const date = parseDateTime(value, this.formats);
-      // show only valid values
-      return date ? date.format('YYYY-MM-DD') : undefined;
+        const date = parseDateTime(value, this.formats);
+        // show only valid values
+        return date ? date.format('YYYY-MM-DD') : undefined;
+      },
+      set(val: string): void {
+        this.onPickerChange(val);
+      },
     },
     clearLabel(): string {
       const label =
@@ -269,8 +276,7 @@ const controlRenderer = defineComponent({
       this.onChange(null);
     },
     okHandler(): void {
-      // cast to 'any' because of Typescript problems (excessive stack depth when comparing types)
-      this.onPickerChange((this.$refs.picker as any).inputDate);
+      (this.$refs.menu as any).save(this.pickerValue);
       this.showMenu = false;
     },
     maskFunction(value: string): (string | RegExp)[] {

--- a/vue2-vuetify/src/controls/TimeControlRenderer.vue
+++ b/vue2-vuetify/src/controls/TimeControlRenderer.vue
@@ -34,6 +34,7 @@
             ref="menu"
             v-model="showMenu"
             :close-on-content-click="false"
+            :return-value.sync="pickerValue"
             transition="scale-transition"
             offset-y
             min-width="290px"
@@ -43,7 +44,7 @@
             </template>
             <v-time-picker
               v-if="showMenu"
-              :value="pickerValue"
+              v-model="pickerValue"
               ref="picker"
               v-bind="vuetifyProps('v-time-picker')"
               :min="minTime"
@@ -254,16 +255,21 @@ const controlRenderer = defineComponent({
       const time = parseDateTime(value, this.formats);
       return time ? time.format(this.timeFormat) : value;
     },
-    pickerValue(): string | undefined {
-      const value = this.control.data;
+    pickerValue: {
+      get(): string | undefined {
+        const value = this.control.data;
 
-      const time = parseDateTime(value, this.formats);
-      // show only valid values
-      return time
-        ? this.useSeconds
-          ? time.format('HH:mm:ss')
-          : time.format('HH:mm')
-        : undefined;
+        const time = parseDateTime(value, this.formats);
+        // show only valid values
+        return time
+          ? this.useSeconds
+            ? time.format('HH:mm:ss')
+            : time.format('HH:mm')
+          : undefined;
+      },
+      set(val: string) {
+        this.onPickerChange(val);
+      },
     },
     clearLabel(): string {
       const label =
@@ -303,8 +309,7 @@ const controlRenderer = defineComponent({
       this.onChange(time ? time.format(this.timeSaveFormat) : value);
     },
     okHandler(): void {
-      // cast to 'any' because of Typescript problems (excessive stack depth when comparing types)
-      this.onPickerChange((this.$refs.picker as any).genValue());
+      (this.$refs.menu as any).save(this.pickerValue);
       this.showMenu = false;
     },
     clear(): void {


### PR DESCRIPTION
Use v-model so that picker will update accordingly as well as the value inside the v-text-input. Use return-value:sync to implement the Cancel (e.g. not clicking on OK should revert the changes)

Fixing issue [69](https://github.com/eclipsesource/jsonforms-vuetify-renderers/issues/69)