### PR TITLE
Allow falsy values like 0, false, empty string to be allowed values f…

### DIFF
--- a/vue2-vuetify/src/controls/EnumControlRenderer.vue
+++ b/vue2-vuetify/src/controls/EnumControlRenderer.vue
@@ -64,9 +64,8 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyControl(
-      useJsonFormsEnumControl(props),
-      (value) => value || undefined
+    return useVuetifyControl(useJsonFormsEnumControl(props), (value) =>
+      value !== null ? value : undefined
     );
   },
 });

--- a/vue2-vuetify/src/controls/OneOfEnumControlRenderer.vue
+++ b/vue2-vuetify/src/controls/OneOfEnumControlRenderer.vue
@@ -64,9 +64,8 @@ const controlRenderer = defineComponent({
     ...rendererProps<ControlElement>(),
   },
   setup(props: RendererProps<ControlElement>) {
-    return useVuetifyControl(
-      useJsonFormsOneOfEnumControl(props),
-      (value) => value || undefined
+    return useVuetifyControl(useJsonFormsOneOfEnumControl(props), (value) =>
+      value !== null ? value : undefined
     );
   },
 });

--- a/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -91,7 +91,7 @@ const controlRenderer = defineComponent({
   setup(props: RendererProps<ControlElement>) {
     return useVuetifyControl(
       useJsonFormsEnumControl(props),
-      (value) => value || undefined,
+      (value) => (value !== null ? value : undefined),
       300
     );
   },

--- a/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/vue2-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -91,7 +91,7 @@ const controlRenderer = defineComponent({
   setup(props: RendererProps<ControlElement>) {
     return useVuetifyControl(
       useJsonFormsOneOfEnumControl(props),
-      (value) => value || undefined,
+      (value) => (value !== null ? value : undefined),
       300
     );
   },

--- a/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue2-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -455,7 +455,7 @@ const controlRenderer = defineComponent({
         schema: this.control.schema,
         uischema: this.control.uischema,
         path: this.control.path,
-        data: this.data,
+        data: this.control.data,
         ...additionalContext,
       };
       const translation = this.t(i18nKey, undefined, context);


### PR DESCRIPTION
…or enums

Example schemas

```
{
  "type": "object",
  "properties": {
    "areYouTall": {
      "type": "boolean",
      "oneOf": [
        {
          "const": true,
          "title": "Yes"
        },
        {
          "const": false,
          "title": "No"
        }
      ]
    }
  },   
  "required": [
    "areYouTall"
  ]
}
```

```
{
  "type": "VerticalLayout",
  "elements": [
    {
      "type": "Control",
      "scope": "#/properties/areYouTall"
    }
  ]
}
```