### PR TITLE
Datetime fixes

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -36,5 +36,8 @@
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "vueCompilerOptions": {
+    "target": 2.7
+  }
 }

--- a/vue2-vuetify/src/controls/DateControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateControlRenderer.vue
@@ -293,9 +293,6 @@ const controlRenderer = defineComponent({
     onYear(year: number): void {
       if (this.pickerType === 'year') {
         this.pickerValue = `${year}`;
-        if (this.$refs?.picker) {
-          (this.$refs.picker as any).internalActivePicker = 'YEAR';
-        }
         if (!this.showActions) {
           this.okHandler();
         }

--- a/vue2-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/vue2-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -414,7 +414,7 @@ const controlRenderer = defineComponent({
         return date ? date.format('YYYY-MM-DD') : undefined;
       },
       set(val: string) {
-        this.onPickerChange(val, (this.$refs.timePicker as any).genValue());
+        this.onPickerChange(val, this.timePickerValue);
       },
     },
     timePickerValue: {
@@ -430,7 +430,7 @@ const controlRenderer = defineComponent({
           : undefined;
       },
       set(val: string) {
-        this.onPickerChange((this.$refs.datePicker as any).inputDate, val);
+        this.onPickerChange(this.datePickerValue, val);
       },
     },
     pickerValue: {
@@ -445,7 +445,9 @@ const controlRenderer = defineComponent({
       },
       set(val: string) {
         const dateTime = parseDateTime(val, 'YYYY-MM-DDTHH:mm:ss.SSSZ');
-        this.onChange(dateTime!.format(this.dateTimeSaveFormat));
+        if (dateTime && this.showActions) {
+          this.onChange(dateTime.format(this.dateTimeSaveFormat));
+        }
       },
     },
     clearLabel(): string {
@@ -484,7 +486,7 @@ const controlRenderer = defineComponent({
         this.onChange(newdata);
       }
     },
-    onPickerChange(dateValue: string, timeValue: string): void {
+    onPickerChange(dateValue?: string, timeValue?: string): void {
       const date = parseDateTime(dateValue, 'YYYY-MM-DD');
       const time = parseDateTime(
         timeValue ?? (this.useSeconds ? '00:00:00' : '00:00'),

--- a/vue2-vuetify/tsconfig.json
+++ b/vue2-vuetify/tsconfig.json
@@ -30,5 +30,8 @@
   "exclude": [
     "node_modules",
     "lib"
-  ]
+  ],
+  "vueCompilerOptions": {
+    "target": 2.7
+  }
 }


### PR DESCRIPTION
Fixes issues when the date-time control is empty. The fix is to ensure that we use the proper values instead of trying to get the value from the UI component which might not be visible (in case of the clock when it is in a tab). This also fixes an issue where if the showActions is false (using one click) then the value should be set no matter if we click outside of the component before finishing selecting all time components but still preserve that "revert" when using action button since we can "Cancel" the changes.