### PR TITLE
fix(EnumControlRenderer.vue): use Vue3 event 

### DIFF
--- a/vue-vuetify/src/controls/EnumControlRenderer.vue
+++ b/vue-vuetify/src/controls/EnumControlRenderer.vue
@@ -24,7 +24,7 @@
         :item-title="(item) => t(item.label, item.label)"
         item-value="value"
         v-bind="vuetifyProps('v-select')"
-        @change="onChange"
+        @update:modelValue="onChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />


### PR DESCRIPTION
This changes the `@change` listener to `@update:model-value` on the v-select used in the Enum renderer.
Fixes #99 