### PR TITLE
Touch error filtering

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "3.2.0-preview-alpha.3",
+  "version": "3.2.1",
   "private": true,
   "scripts": {
     "build": "vue-cli-service build",
@@ -8,9 +8,9 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@jsonforms/core": "3.2.0-alpha.3",
-    "@jsonforms/vue": "3.2.0-alpha.3",
-    "@jsonforms/vue-vuetify": "^3.2.0-preview-alpha.3",
+    "@jsonforms/core": "3.2.1",
+    "@jsonforms/vue": "3.2.1",
+    "@jsonforms/vue-vuetify": "3.2.1",
     "ajv-keywords": "^5.1.0",
     "core-js": "^3.9.1",
     "json-refs": "^3.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-typescript": "^7.14.5",
-        "@jsonforms/core": "3.2.0-alpha.3",
-        "@jsonforms/vue": "3.2.0-alpha.3",
+        "@jsonforms/core": "3.2.1",
+        "@jsonforms/vue": "3.2.1",
         "@mdi/font": "^7.0.96",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -3312,9 +3312,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jsonforms/core": {
-      "version": "3.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-3.2.0-alpha.3.tgz",
-      "integrity": "sha512-yMDTP5zj9H1Xng0tozdPIYYb0trzQpu3bZ2l1U303Fu1/sQFuTcmovUlfGZg01qvYR95pdY66GuRTJZDrCUmew==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-G5ldiWM2e5Vh5WrbjDKb0QJ1SG/39kxC48x2ufFKhfpDHibqhPaXegg5jmSBTNcB0ldE9jMmpKwxF6fi5VBCEA==",
       "dependencies": {
         "@types/json-schema": "^7.0.3",
         "ajv": "^8.6.1",
@@ -3323,14 +3323,14 @@
       }
     },
     "node_modules/@jsonforms/vue": {
-      "version": "3.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jsonforms/vue/-/vue-3.2.0-alpha.3.tgz",
-      "integrity": "sha512-P/oEDuwqHr3v71T4KucgfK1u2NDeOAUnYZtq+a4Y5H5bS1Ig1LAVE8hlpd5CFT4gg0d8YIA9ZmMJZMONuWz0gg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonforms/vue/-/vue-3.2.1.tgz",
+      "integrity": "sha512-Aube7hIneWLP/1PSW5Hhii+VOZX1ijMDEmI6jMhrUSDaz7TAgjTP0V5fIC54/xos8c7PB3/GFUUs2nD4khy3Ug==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@jsonforms/core": "3.2.0-alpha.3",
+        "@jsonforms/core": "3.2.1",
         "vue": "^3.2.26"
       }
     },
@@ -27132,9 +27132,9 @@
       }
     },
     "@jsonforms/core": {
-      "version": "3.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-3.2.0-alpha.3.tgz",
-      "integrity": "sha512-yMDTP5zj9H1Xng0tozdPIYYb0trzQpu3bZ2l1U303Fu1/sQFuTcmovUlfGZg01qvYR95pdY66GuRTJZDrCUmew==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-G5ldiWM2e5Vh5WrbjDKb0QJ1SG/39kxC48x2ufFKhfpDHibqhPaXegg5jmSBTNcB0ldE9jMmpKwxF6fi5VBCEA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
         "ajv": "^8.6.1",
@@ -27143,9 +27143,9 @@
       }
     },
     "@jsonforms/vue": {
-      "version": "3.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jsonforms/vue/-/vue-3.2.0-alpha.3.tgz",
-      "integrity": "sha512-P/oEDuwqHr3v71T4KucgfK1u2NDeOAUnYZtq+a4Y5H5bS1Ig1LAVE8hlpd5CFT4gg0d8YIA9ZmMJZMONuWz0gg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonforms/vue/-/vue-3.2.1.tgz",
+      "integrity": "sha512-Aube7hIneWLP/1PSW5Hhii+VOZX1ijMDEmI6jMhrUSDaz7TAgjTP0V5fIC54/xos8c7PB3/GFUUs2nD4khy3Ug==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/vue-vuetify/package.json
+++ b/vue-vuetify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonforms/vue-vuetify",
-  "version": "3.2.0-preview-alpha.3",
+  "version": "3.2.1",
   "description": "Vue Vuetify renderers for JSON Forms",
   "repository": "https://github.com/eclipsesource/jsonforms-vuetify-renderers",
   "bugs": "https://github.com/eclipsesource/jsonforms/issues",
@@ -47,8 +47,8 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "@jsonforms/core": "3.2.0-alpha.3",
-    "@jsonforms/vue": "3.2.0-alpha.3",
+    "@jsonforms/core": "3.2.1",
+    "@jsonforms/vue": "3.2.1",
     "@mdi/font": "^7.0.96",
     "vue": "^3.2.47",
     "vuetify": "^3.1.12"
@@ -57,8 +57,8 @@
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-typescript": "^7.14.5",
-    "@jsonforms/core": "3.2.0-alpha.3",
-    "@jsonforms/vue": "3.2.0-alpha.3",
+    "@jsonforms/core": "3.2.1",
+    "@jsonforms/vue": "3.2.1",
     "@mdi/font": "^7.0.96",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/vue-vuetify/src/complex/ArrayControlRenderer.vue
+++ b/vue-vuetify/src/complex/ArrayControlRenderer.vue
@@ -255,7 +255,7 @@ const controlRenderer = defineComponent({
     addButtonClick() {
       this.addItem(
         this.control.path,
-        createDefaultValue(this.control.schema)
+        createDefaultValue(this.control.schema, this.control.rootSchema)
       )();
     },
     moveUpClick(event: Event, toMove: number): void {

--- a/vue-vuetify/src/complex/OneOfRenderer.vue
+++ b/vue-vuetify/src/complex/OneOfRenderer.vue
@@ -185,7 +185,8 @@ const controlRenderer = defineComponent({
         this.path,
         this.newSelectedIndex !== undefined && this.newSelectedIndex !== null
           ? createDefaultValue(
-              this.indexedOneOfRenderInfos[this.newSelectedIndex].schema
+              this.indexedOneOfRenderInfos[this.newSelectedIndex].schema,
+              this.control.rootSchema
             )
           : {}
       );

--- a/vue-vuetify/src/complex/OneOfRenderer.vue
+++ b/vue-vuetify/src/complex/OneOfRenderer.vue
@@ -26,8 +26,8 @@
         item-value="index"
         v-model="selectIndex"
         v-bind="vuetifyProps('v-select')"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       ></v-select>
     </v-hover>
     <dispatch-renderer

--- a/vue-vuetify/src/complex/OneOfTabRenderer.vue
+++ b/vue-vuetify/src/complex/OneOfTabRenderer.vue
@@ -171,7 +171,10 @@ const controlRenderer = defineComponent({
     openNewTab(): void {
       this.handleChange(
         this.path,
-        createDefaultValue(this.oneOfRenderInfos[this.newSelectedIndex].schema)
+        createDefaultValue(
+            this.oneOfRenderInfos[this.newSelectedIndex].schema,
+            this.control.rootSchema
+        )
       );
       this.tabIndex = this.newSelectedIndex;
       this.selectedIndex = this.newSelectedIndex;

--- a/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -425,7 +425,10 @@ export default defineComponent({
                 (newData[ap.propertyName] === null &&
                   ap.schema.type !== 'null')) // createDefaultValue will return null only when the ap.schema.type is 'null'
             ) {
-              const newValue = createDefaultValue(ap.schema);
+              const newValue = createDefaultValue(
+                  ap.schema,
+                  this.control.rootSchema
+              );
               hasChanges = newData[ap.propertyName] !== newValue;
               newData[ap.propertyName] = newValue;
             }
@@ -466,7 +469,7 @@ export default defineComponent({
           additionalProperty.schema
         ) {
           this.control.data[this.newPropertyName] = createDefaultValue(
-            additionalProperty.schema
+            additionalProperty.schema, this.control.rootSchema
           );
           // we need always to preserve the key even when the value is "empty"
           this.input.handleChange(this.control.path, this.control.data);

--- a/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.vue
+++ b/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.vue
@@ -31,8 +31,8 @@
         :clearable="isHovering"
         v-bind="vuetifyProps('v-combobox')"
         @change="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/BooleanControlRenderer.vue
+++ b/vue-vuetify/src/controls/BooleanControlRenderer.vue
@@ -20,8 +20,8 @@
       :model-value="control.data"
       v-bind="vuetifyProps('v-checkbox')"
       @change="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     />
   </control-wrapper>
 </template>

--- a/vue-vuetify/src/controls/BooleanToggleControlRenderer.vue
+++ b/vue-vuetify/src/controls/BooleanToggleControlRenderer.vue
@@ -22,8 +22,8 @@
       :false-value="false"
       v-bind="vuetifyProps('v-switch')"
       @change="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     />
   </control-wrapper>
 </template>

--- a/vue-vuetify/src/controls/DateControlRenderer.vue
+++ b/vue-vuetify/src/controls/DateControlRenderer.vue
@@ -19,8 +19,8 @@
       v-bind="vuetifyProps('v-text-field')"
       :model-value="control.data"
       @update:model-value="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
       type="date"
     />
   </control-wrapper>

--- a/vue-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/vue-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -19,8 +19,8 @@
       v-bind="vuetifyProps('v-text-field')"
       :model-value="dataTime"
       @update:model-value="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
       type="datetime-local"
     >
     </v-text-field>

--- a/vue-vuetify/src/controls/EnumControlRenderer.vue
+++ b/vue-vuetify/src/controls/EnumControlRenderer.vue
@@ -25,8 +25,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-select')"
         @update:modelValue="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/IntegerControlRenderer.vue
+++ b/vue-vuetify/src/controls/IntegerControlRenderer.vue
@@ -23,8 +23,8 @@
         :clearable="isHovering"
         v-bind="vuetifyProps('v-text-field')"
         @update:model-value="onInputChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       ></v-text-field>
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/MultiStringControlRenderer.vue
+++ b/vue-vuetify/src/controls/MultiStringControlRenderer.vue
@@ -31,8 +31,8 @@
         multi-line
         v-bind="vuetifyProps('v-textarea')"
         @update:model-value="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -23,8 +23,8 @@
         :clearable="isHovering"
         v-bind="vuetifyProps('v-text-field')"
         @update:model-value="onInputChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       ></v-text-field>
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/OneOfEnumControlRenderer.vue
+++ b/vue-vuetify/src/controls/OneOfEnumControlRenderer.vue
@@ -25,8 +25,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.vue
+++ b/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.vue
@@ -21,8 +21,8 @@
       v-bind="vuetifyProps('v-radio-group')"
       :model-value="control.data"
       @change="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     >
       <v-radio
         v-for="o in control.options"

--- a/vue-vuetify/src/controls/PasswordControlRenderer.vue
+++ b/vue-vuetify/src/controls/PasswordControlRenderer.vue
@@ -30,8 +30,8 @@
       "
       v-bind="vuetifyProps('v-text-field')"
       @update:model-value="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     />
   </control-wrapper>
 </template>

--- a/vue-vuetify/src/controls/RadioGroupControlRenderer.vue
+++ b/vue-vuetify/src/controls/RadioGroupControlRenderer.vue
@@ -21,8 +21,8 @@
       :model-value="control.data"
       v-bind="vuetifyProps('v-radio-group')"
       @change="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     >
       <v-radio
         v-for="o in control.options"

--- a/vue-vuetify/src/controls/SliderControlRenderer.vue
+++ b/vue-vuetify/src/controls/SliderControlRenderer.vue
@@ -23,8 +23,8 @@
       :model-value="control.data"
       v-bind="vuetifyProps('v-slider')"
       @update:model-value="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
     />
   </control-wrapper>
 </template>

--- a/vue-vuetify/src/controls/StringControlRenderer.vue
+++ b/vue-vuetify/src/controls/StringControlRenderer.vue
@@ -1,5 +1,4 @@
 <template>
-  <p class="text-red">live</p>
   <control-wrapper
     v-bind="controlWrapper"
     :styles="styles"
@@ -34,8 +33,8 @@
         hide-no-data
         v-bind="vuetifyProps('v-combobox')"
         @update:model-value="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
       <v-text-field
         v-else
@@ -61,8 +60,8 @@
         :clearable="isHovering"
         v-bind="vuetifyProps('v-text-field')"
         @update:model-value="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/controls/StringControlRenderer.vue
+++ b/vue-vuetify/src/controls/StringControlRenderer.vue
@@ -1,4 +1,5 @@
 <template>
+  <p class="text-red">live</p>
   <control-wrapper
     v-bind="controlWrapper"
     :styles="styles"

--- a/vue-vuetify/src/controls/StringMaskControlRenderer.vue
+++ b/vue-vuetify/src/controls/StringMaskControlRenderer.vue
@@ -28,8 +28,8 @@
         "
         :clearable="isHovering"
         v-bind="vuetifyProps('v-text-field')"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
         v-model="maskModel"
         v-mask="mask"
       />

--- a/vue-vuetify/src/controls/TimeControlRenderer.vue
+++ b/vue-vuetify/src/controls/TimeControlRenderer.vue
@@ -19,8 +19,8 @@
       v-bind="vuetifyProps('v-text-field')"
       :model-value="control.data"
       @update:model-value="onChange"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
+      @focus="handleFocus"
+      @blur="handleBlur"
       type="time"
     >
     </v-text-field>

--- a/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -26,8 +26,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
       <v-autocomplete
         v-else
@@ -49,8 +49,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-autocomplete')"
         @update:model-value="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -26,8 +26,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-select')"
         @change="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
       <v-autocomplete
         v-else
@@ -49,8 +49,8 @@
         item-value="value"
         v-bind="vuetifyProps('v-autocomplete')"
         @update:model-value="onChange"
-        @focus="isFocused = true"
-        @blur="isFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
       />
     </v-hover>
   </control-wrapper>

--- a/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -434,7 +434,7 @@ const controlRenderer = defineComponent({
       }
     },
     childErrors(index: number): ErrorObject[] {
-      return this.control.childErrors.filter((e) => {
+      return this.control.childErrors.filter((e: ErrorObject) => {
         const errorDataPath = getControlPath(e);
         return errorDataPath.startsWith(
           this.composePaths(this.control.path, `${index}`)

--- a/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -411,7 +411,10 @@ const controlRenderer = defineComponent({
     addButtonClick() {
       this.addItem(
         this.control.path,
-        createDefaultValue(this.control.schema)
+        createDefaultValue(
+            this.control.schema,
+            this.control.rootSchema
+        )
       )();
       if (!this.appliedOptions.collapseNewItems && this.control.data?.length) {
         this.currentlyExpanded = this.dataLength - 1;


### PR DESCRIPTION
This PR adds a touched ref that is bound to controls from
`useVuetifyControl` and a `handleBlur` composable that updates the
`touched` state after an input is blurred.

It also takes account of a new config setting `enableFilterErrorsBeforeTouch`
which allows the forcing of all errors to display, such as when a user
attempts to submit a form which is not completely valid.