### PR TITLE
Explicit ESM exports

### DIFF
--- a/vue-vuetify/package.json
+++ b/vue-vuetify/package.json
@@ -30,6 +30,14 @@
   ],
   "main": "lib/jsonforms-vue-vuetify.cjs.js",
   "module": "lib/jsonforms-vue-vuetify.esm.js",
+  "exports": {
+    ".": {
+      "import": "./lib/jsonforms-vue-vuetify.esm.js",
+      "require": "./lib/jsonforms-vue-vuetify.cjs.js"
+    },
+    "./lib/jsonforms-vue-vuetify.esm.css": "./lib/jsonforms-vue-vuetify.esm.css",
+    "./lib/jsonforms-vue-vuetify.cjs.css": "./lib/jsonforms-vue-vuetify.cjs.css"
+  },
   "typings": "lib/index.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
This PR adds an explicit `exports` section to `package.json`.

This is required for node.js imports to pick up the correct ESM output.
For example, when importing jsonforms/vue-vuetify within a test framework
such as Vitest, or Playwright Component Testing when using ES modules.


