### PR TITLE
Export renderers for all controls

### DIFF
--- a/vue-vuetify/src/additional/index.ts
+++ b/vue-vuetify/src/additional/index.ts
@@ -8,3 +8,7 @@ export const additionalRenderers = [
   labelRendererEntry,
   // listWithDetailRendererEntry,
 ];
+
+export {
+  labelRendererEntry
+}

--- a/vue-vuetify/src/complex/index.ts
+++ b/vue-vuetify/src/complex/index.ts
@@ -23,3 +23,13 @@ export const complexRenderers = [
   oneOfRendererEntry,
   oneOfTabRendererEntry,
 ];
+
+export {
+  allOfRendererEntry,
+  anyOfRendererEntry,
+  arrayControlRendererEntry,
+  enumArrayRendererEntry,
+  objectRendererEntry,
+  oneOfRendererEntry,
+  oneOfTabRendererEntry,
+}

--- a/vue-vuetify/src/controls/index.ts
+++ b/vue-vuetify/src/controls/index.ts
@@ -57,3 +57,22 @@ export const controlRenderers = [
   // stringMaskControlRendererEntry,
   timeControlRendererEntry,
 ];
+export {
+  anyOfStringOrEnumControlRendererEntry,
+  booleanControlRendererEntry,
+  booleanToggleControlRendererEntry,
+  dateControlRendererEntry,
+  dateTimeControlRendererEntry,
+  enumControlRendererEntry,
+  integerControlRendererEntry,
+  multiStringControlRendererEntry,
+  numberControlRendererEntry,
+  oneOfEnumControlRendererEntry,
+  oneOfRadioGroupControlRendererEntry,
+  passwordControlRendererEntry,
+  radioGroupControlRendererEntry,
+  sliderControlRendererEntry,
+  stringControlRendererEntry,
+  // stringMaskControlRendererEntry,
+  timeControlRendererEntry,
+};

--- a/vue-vuetify/src/extended/index.ts
+++ b/vue-vuetify/src/extended/index.ts
@@ -8,3 +8,8 @@ export const extendedRenderers = [
   autocompleteEnumControlRendererEntry,
   autocompleteOneOfEnumControlRendererEntry,
 ];
+
+export {
+  autocompleteEnumControlRendererEntry,
+  autocompleteOneOfEnumControlRendererEntry,
+}


### PR DESCRIPTION
This allows consuming applications to refer to the upstream in downstream renderer entries, for example when using `withIncreasedRank` and wishing to pass in `UpstreamControlRendererEntry.tester`.
