### PR TITLE
fix: nested additional props cause data corruption

### DIFF
--- a/vue2-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/vue2-vuetify/src/complex/components/AdditionalProperties.vue
@@ -231,15 +231,17 @@ export default defineComponent({
           (propUiSchema as GroupLayout).label =
             propSchema.title ?? startCase(propName);
         } else {
-          propUiSchema = createControlElement(
-            control.value.path + '/' + encode(propName)
+          const encodedPath = composePaths(
+            control.value.path,
+            encode(propName)
           );
+          propUiSchema = createControlElement(encodedPath);
         }
       }
 
       return {
         propertyName: propName,
-        path: composePaths(control.value.path, propName),
+        path: composePaths(control.value.path, encode(propName)),
         schema: propSchema,
         uischema: propUiSchema,
       };


### PR DESCRIPTION
Fixed invalid path composition that causes nested additional properties to have invalid values.

An example that previously wouldn't have worked:

`{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "SomeNestedConfig": {
      "type": "object",
      "default": {},
      "properties": {
        "CsvImportDirectory": {
          "type": ["string", "null"],
          "default": "import"
        },
        "KeyToValueMapping": {
          "type": "object",
          "patternProperties": {
            ".*": {
              "type": "string",
              "title": "Key"
            }
          },
          "additionalProperties": {
            "type": "string",
            "title": "Value"
          },
          "default": {}

        }
      },
      "required": ["CsvImportDirectory", "KeyToValueMapping"],
      "additionalProperties": true
    }
  },

  "required": [
    "SomeNestedConfig"
  ],
  "additionalProperties": true
}`

Now it produces valid output.